### PR TITLE
feat: new command for Frank

### DIFF
--- a/commands/frank.js
+++ b/commands/frank.js
@@ -1,0 +1,9 @@
+import { MessageFlags } from "discord.js"
+
+export const name = "frank"
+
+export async function run(client, interaction) {
+    interaction.reply({
+        content: "https://cdn.pestoverse.world/yunya/frank_rejected.png"
+    })
+}

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -229,6 +229,11 @@ const commands = [
 	new SlashCommandBuilder()
 	.setName("council")
 	.setDescription("Shows the top 10 average power users across all checks from last month.")
+	.setDefaultMemberPermissions(PermissionFlagsBits.SendMessages),
+	//frank command
+	new SlashCommandBuilder()
+	.setName("frank")
+	.setDescription("Ouch, Rest In Pesto, Frank")
 	.setDefaultMemberPermissions(PermissionFlagsBits.SendMessages)
 ];
 

--- a/utils/messages.js
+++ b/utils/messages.js
@@ -81,7 +81,7 @@ export function getHorniMessage(power) {
 
 export function getPestoCoinsMessage(negative) {
 	if (negative) {
-		return "# Council Penalty\nThe __Pesto Council__ withdraws **-{coins}** pesto coins as part of a yuniverse realignment!";
+		return "# Council Penalty\nThe __Pesto Council__ withdraws **{coins}** pesto coins as part of a Yuniverse realignment!";
 	} else {
 		return "# Council Reward\nThe __Pesto Council__ rewards you with **+{coins}** pesto coins for doing your daily checks!";
 	}


### PR DESCRIPTION
implements a new commands that makes the bot send a screenshot of a painful moment in chat
command: /frank

also fixed the double negative issue that appeared when a Pestie got negative coins.